### PR TITLE
Adapt to new spatstat.random package.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ LinkingTo:
     Rcpp
 Suggests:
     rmarkdown,
-    spatstat.geom, spatstat.core, spatstat (>= 2.0-0),
+    spatstat.geom, spatstat.random,
     testthat,
     knitr
 VignetteBuilder: knitr

--- a/R/Sample_quadrats.R
+++ b/R/Sample_quadrats.R
@@ -60,13 +60,13 @@ sample_quadrats <- function(comm, n_quadrats = 20, quadrat_area = 0.01,
 
             if (avoid_overlap == TRUE){
 
-               if (requireNamespace("spatstat.core", quietly = TRUE)){
+               if (requireNamespace("spatstat.random", quietly = TRUE)){
 
                   # Hard core process:
                   hc_mod <- list(cif = "hardcore", par = list(beta = n_quadrats, hc = min_dist),
                                  w = spatstat.geom::owin(c(comm$x_min_max[1], comm$x_min_max[2] - quadrat_size),
                                                     c(comm$y_min_max[1], comm$y_min_max[2] - quadrat_size)))
-                  hc_points <- spatstat.core::rmh(model = hc_mod, start=list(n.start = n_quadrats),
+                  hc_points <- spatstat.random::rmh(model = hc_mod, start=list(n.start = n_quadrats),
                                              control=list(p = 1, nrep = 1e6),
                                              saveinfo = F, verbose = F)
                   xpos <- hc_points$x

--- a/R/Sim_Community.R
+++ b/R/Sim_Community.R
@@ -558,7 +558,7 @@ sim_poisson_community <- function(s_pool,
 #' plot dimension, a random Poisson distribution is simulated, which is more
 #' efficient than a Thomas cluster process. The parameter \code{sigma} corresponds
 #' to the \code{scale} parameter of the function \code{rThomas} in the package
-#' \href{https://CRAN.R-project.org/package=spatstat}{spatstat}.
+#' \href{https://CRAN.R-project.org/package=spatstat.random}{spatstat.random}.
 #'
 #'
 #' @param mother_points Number of mother points (= cluster centres).
@@ -576,7 +576,7 @@ sim_poisson_community <- function(s_pool,
 #' a specific mean number of points per cluster.  If no value is provided, the
 #' number of points per cluster is determined from the abundance and from
 #' \code{mother_points}.  The parameter \code{cluster_points} corresponds to the
-#' \code{mu} parameter of \code{spatstat.core::rThomas}.
+#' \code{mu} parameter of \code{spatstat.random::rThomas}.
 #'
 #' @param xrange Extent of the community in x-direction (numeric vector of length 2)
 #' @param yrange Extent of the community in y-direction (numeric vector of length 2)
@@ -616,7 +616,7 @@ sim_poisson_community <- function(s_pool,
 #'
 #' @author Felix May
 #'
-#' @seealso \code{\link[spatstat.core]{rThomas}}
+#' @seealso \code{\link[spatstat.random]{rThomas}}
 #'
 #' @examples
 #'

--- a/man/sim_thomas_coords.Rd
+++ b/man/sim_thomas_coords.Rd
@@ -25,7 +25,7 @@ When \code{sigma} of any species is more than twice as large as the largest
 plot dimension, a random Poisson distribution is simulated, which is more
 efficient than a Thomas cluster process. The parameter \code{sigma} corresponds
 to the \code{scale} parameter of the function \code{rThomas} in the package
-\href{https://CRAN.R-project.org/package=spatstat}{spatstat}.}
+\href{https://CRAN.R-project.org/package=spatstat.random}{spatstat.random}.}
 
 \item{mother_points}{Number of mother points (= cluster centres).
 If this is a single value, all species have the same number of clusters.
@@ -42,7 +42,7 @@ If this is a vector of the same length as \code{abund_vec}, each species has
 a specific mean number of points per cluster.  If no value is provided, the
 number of points per cluster is determined from the abundance and from
 \code{mother_points}.  The parameter \code{cluster_points} corresponds to the
-\code{mu} parameter of \code{spatstat.core::rThomas}.}
+\code{mu} parameter of \code{spatstat.random::rThomas}.}
 
 \item{xrange}{Extent of the community in x-direction (numeric vector of length 2)}
 
@@ -108,7 +108,7 @@ Wiegand and Moloney 2014. Handbook of Spatial Point-Pattern Analysis in Ecology.
 CRC Press
 }
 \seealso{
-\code{\link[spatstat.core]{rThomas}}
+\code{\link[spatstat.random]{rThomas}}
 }
 \author{
 Felix May


### PR DESCRIPTION
Random generators are being moved from `spatstat.core` to a new package `spatstat.random`. This should hopefully fix the problem for your package.